### PR TITLE
Add rawJsonString()

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,11 @@ int sendAt = header.getSendAt();
 String headers = header.jsonString();
 ```
 
+If you need the unescaped JSON string.
+```java
+String rawJson = header.rawJsonString();
+```
+
 ## Running Tests
 
 ```

--- a/src/main/java/com/sendgrid/smtpapi/SMTPAPI.java
+++ b/src/main/java/com/sendgrid/smtpapi/SMTPAPI.java
@@ -231,4 +231,8 @@ public class SMTPAPI {
   public String jsonString() {
     return escapeUnicode(this.header.toString());
   }
+
+  public String rawJsonString() {
+    return this.header.toString();
+  }
 }

--- a/src/test/java/com/sendgrid/smtpapi/SMTPAPITest.java
+++ b/src/test/java/com/sendgrid/smtpapi/SMTPAPITest.java
@@ -76,6 +76,14 @@ public class SMTPAPITest {
     Assert.assertEquals(expected, test.jsonString());
   }
 
+  @Test public void testRawJsonString() {
+    test.addCategory("カテゴリUñicode");
+    test.addCategory("カテゴリ2Unicode");
+    test.addCategory("鼖");
+    String expected = "{\"category\":[\"カテゴリUñicode\",\"カテゴリ2Unicode\",\"鼖\"]}";
+    Assert.assertEquals(expected, test.rawJsonString());
+  }
+
   @Test public void testAddCategories() throws JSONException {
     String[] expected = new String[]{"test", "test2"};
     test.addCategories(expected);


### PR DESCRIPTION
When I use smtpapi-java with JavaMail, it is better to handle unescaped JSON string, because JavaMail has ability to fold and encode the custom headers.
If the x-smtpapi header is longer than 1000 characters, we have to fold it(add line break per 1000 characters).
http://docs.oracle.com/javaee/6/api/javax/mail/internet/MimeUtility.html#encodeText(java.lang.String)
http://docs.oracle.com/javaee/6/api/javax/mail/internet/MimeUtility.html#fold(int, java.lang.String)
