### PR TITLE
[Fixes #63] Updated SMTPAPI.java import order

### DIFF
--- a/src/main/java/com/sendgrid/smtpapi/SMTPAPI.java
+++ b/src/main/java/com/sendgrid/smtpapi/SMTPAPI.java
@@ -1,11 +1,11 @@
 package com.sendgrid.smtpapi;
 
-import java.util.Map;
 import java.util.ArrayList;
+import java.util.Map;
 
 import org.json.JSONArray;
-import org.json.JSONObject;
 import org.json.JSONException;
+import org.json.JSONObject;
 
 public class SMTPAPI {
 


### PR DESCRIPTION
Moved ArrayList and JsonObject imports to correct lexicographical order

<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.


Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
Fixes #63 

### Checklist
- [ X] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [ X] I have read the [Contribution Guide] and my PR follows them.
- [ X] I updated my branch with the master branch.
- [X ] I have added tests that prove my fix is effective or that my feature works
- [ X] I have added necessary documentation about the functionality in the appropriate .md file
- [X ] I have added in line documentation to the code I modified

### Short description of what this PR does:
- Fixes order of imports in SMTPAPI.java to correct lexcographic order

If you have questions, please send an email to [Sendgrid](mailto:dx@sendgrid.com), or file a Github Issue in this repository.
