### PR TITLE
feat: add send_each_at header parameter

### DIFF
--- a/examples/Example.java
+++ b/examples/Example.java
@@ -68,6 +68,9 @@ public class Example {
     // [Scheduling](https://sendgrid.com/docs/API_Reference/SMTP_API/scheduling_parameters.html)
     header.setSendAt(1416427645);
 
+    // [Per email scheduling](https://docs.sendgrid.com/for-developers/sending-email/scheduling-parameters)
+    header.addSendEachAt(1416427645);
+
     //int sendAt = header.getSendAt();
 
     // Get Headers

--- a/src/main/java/com/sendgrid/smtpapi/SMTPAPI.java
+++ b/src/main/java/com/sendgrid/smtpapi/SMTPAPI.java
@@ -2,6 +2,7 @@ package com.sendgrid.smtpapi;
 
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -203,7 +204,23 @@ public class SMTPAPI {
 
   public int getSendAt() throws JSONException {
     return this.header.getInt("send_at");
+  }
 
+  public SMTPAPI addSendEachAt(int sendAt) throws JSONException {
+    if (!this.header.has("send_each_at")) {
+      this.header.put("send_each_at", new JSONArray());
+    }
+    this.header.accumulate("send_each_at", sendAt);
+    return this;
+  }
+
+  public List<Integer> getSendEachAt() throws JSONException {
+    JSONArray array = this.header.getJSONArray("send_each_at");
+    List<Integer> sendTimes = new ArrayList<>();
+    for (int i = 0; i < array.length(); i++) {
+      sendTimes.add(array.getInt(i));
+    }
+    return sendTimes;
   }
 
   // convert from string to code point array

--- a/src/test/java/com/sendgrid/smtpapi/SMTPAPITest.java
+++ b/src/test/java/com/sendgrid/smtpapi/SMTPAPITest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.*;
 
 import java.io.*;
 import java.util.Calendar;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -149,6 +150,14 @@ public class SMTPAPITest {
     int expected = 12345;
     test.setSendAt(expected);
     Assert.assertEquals(expected, test.getSendAt());
+  }
+
+  @Test public void testSetSendEachAt() throws JSONException {
+    int expected = 12345;
+    test.addSendEachAt(expected);
+    List<Integer> output = test.getSendEachAt();
+    Assert.assertEquals(1, output.size());
+    Assert.assertEquals(expected, test.getSendEachAt().get(0), 0);
   }
 
   @Test public void testCopyrightDateRange() throws JSONException {


### PR DESCRIPTION
This PR adds the `send_each_at` header option that is currently missing from the Java version of the smtpapi, which is included in for [instance the Python version](https://github.com/sendgrid/smtpapi-python/commit/4aa9266607d7ebf1e5749a743d5b4ee7fd153e69) and is allowed [according to the API documentation](https://docs.sendgrid.com/for-developers/sending-email/scheduling-parameters#example-of-send_each_at-email-header).

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/smtpapi-java/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://support.sendgrid.com).
